### PR TITLE
Do not generate the same UseClass wrappers multiple times

### DIFF
--- a/super_enum/lib/src/annotations.dart
+++ b/super_enum/lib/src/annotations.dart
@@ -38,6 +38,7 @@ class DataField<T> {
 @immutable
 class UseClass {
   final Type type;
+  final String name;
 
-  const UseClass(this.type);
+  const UseClass(this.type, {this.name});
 }

--- a/super_enum_generator/lib/src/class_generator.dart
+++ b/super_enum_generator/lib/src/class_generator.dart
@@ -84,14 +84,14 @@ class ClassGenerator {
         final wrapperName = type_processor.usedWrapperNameFromAnnotation(field);
         _bodyBuffer.writeln('return ${getCamelCase(field.name)}'
             '((this as $wrapperName)'
-            '.${getCamelCase(usedClass.toTypeValue().name)});');
+            '.${getCamelCase(usedClass.toTypeValue().getDisplayString())});');
       } else {
         _bodyBuffer.writeln(
             'return ${getCamelCase(field.name)}(this as ${field.name});');
       }
 
       final callbackArgType = usedClass != null
-          ? '${usedClass.toTypeValue().name}'
+          ? '${usedClass.toTypeValue().getDisplayString()}'
           : '${field.name}';
       _params.add(Parameter((p) {
         return p
@@ -141,14 +141,14 @@ class ClassGenerator {
         final wrapperName = type_processor.usedWrapperNameFromAnnotation(field);
         _bodyBuffer.writeln('return ${getCamelCase(field.name)}'
             '((this as $wrapperName)'
-            '.${getCamelCase(usedClass.toTypeValue().name)});');
+            '.${getCamelCase(usedClass.toTypeValue().getDisplayString())});');
       } else {
         _bodyBuffer.writeln(
             'return ${getCamelCase(field.name)}(this as ${field.name});');
       }
 
       final callbackArgType = usedClass != null
-          ? '${usedClass.toTypeValue().name}'
+          ? '${usedClass.toTypeValue().getDisplayString()}'
           : '${field.name}';
       _params.add(Parameter((p) => p
         ..name = '${getCamelCase(field.name)}'
@@ -211,14 +211,14 @@ class ClassGenerator {
         final wrapperName = type_processor.usedWrapperNameFromAnnotation(field);
         _bodyBuffer.writeln('return ${getCamelCase(field.name)}'
             '((this as $wrapperName)'
-            '.${getCamelCase(usedClass.toTypeValue().name)});');
+            '.${getCamelCase(usedClass.toTypeValue().getDisplayString())});');
       } else {
         _bodyBuffer.writeln(
             'return ${getCamelCase(field.name)}(this as ${field.name});');
       }
 
       final callbackArgType = usedClass != null
-          ? '${usedClass.toTypeValue().name}'
+          ? '${usedClass.toTypeValue().getDisplayString()}'
           : '${field.name}';
       _params.add(Parameter((p) => p
         ..name = '${getCamelCase(field.name)}'
@@ -259,8 +259,8 @@ class ClassGenerator {
         redirectConstructorName =
             type_processor.usedWrapperNameFromAnnotation(field);
         reqParams.add(Parameter((p) => p
-          ..name = '${getCamelCase(usedClass.toTypeValue().name)}'
-          ..type = Reference(usedClass.toTypeValue().name)
+          ..name = '${getCamelCase(usedClass.toTypeValue().getDisplayString())}'
+          ..type = Reference(usedClass.toTypeValue().getDisplayString())
           ..build()));
       }
       return Constructor((constructor) => constructor
@@ -420,7 +420,7 @@ class ClassGenerator {
 
   Class _generateClassWrapper(FieldElement field) {
     final usedClass = type_processor.usedClassFromAnnotation(field);
-    final usedClassType = usedClass.toTypeValue().name;
+    final usedClassType = usedClass.toTypeValue().getDisplayString();
     final wrapperName = type_processor.usedWrapperNameFromAnnotation(field);
     if (wrapper.contains(wrapperName)) {
       // Skip wrapper generation, wrapper already exists
@@ -455,9 +455,9 @@ class ClassGenerator {
       ..annotations.add(references.immutable)
       ..fields.add(Field((f) {
         return f
-          ..name = getCamelCase(usedClass.toTypeValue().name)
+          ..name = getCamelCase(usedClass.toTypeValue().getDisplayString())
           ..modifier = FieldModifier.final$
-          ..type = Reference(usedClass.toTypeValue().name);
+          ..type = Reference(usedClass.toTypeValue().getDisplayString());
       }))
       ..methods.addAll([toString, getProps])
       ..extend = refer('${element.name.replaceFirst('_', '')}')

--- a/super_enum_generator/lib/src/type_processor.dart
+++ b/super_enum_generator/lib/src/type_processor.dart
@@ -47,7 +47,7 @@ String usedWrapperNameFromAnnotation(FieldElement field) {
       TypeChecker.fromRuntime(UseClass).firstAnnotationOfExact(field);
   if (annotation == null) return null;
   final DartObject usedClass = annotation.getField('name');
-  return usedClass.toStringValue() ?? _defaultWrapper(field);
+  return usedClass?.toStringValue() ?? _defaultWrapper(field);
 }
 
 String _defaultWrapper(FieldElement field) {

--- a/super_enum_generator/lib/src/type_processor.dart
+++ b/super_enum_generator/lib/src/type_processor.dart
@@ -41,3 +41,17 @@ DartObject usedClassFromAnnotation(FieldElement field) {
   final DartObject usedClass = annotation.getField('type');
   return usedClass;
 }
+
+String usedWrapperNameFromAnnotation(FieldElement field) {
+  final annotation =
+      TypeChecker.fromRuntime(UseClass).firstAnnotationOfExact(field);
+  if (annotation == null) return null;
+  final DartObject usedClass = annotation.getField('name');
+  return usedClass.toStringValue() ?? _defaultWrapper(field);
+}
+
+String _defaultWrapper(FieldElement field) {
+  final usedClass = usedClassFromAnnotation(field);
+  final usedClassType = usedClass.toTypeValue().name;
+  return '${usedClassType}Wrapper';
+}

--- a/super_enum_generator/lib/src/type_processor.dart
+++ b/super_enum_generator/lib/src/type_processor.dart
@@ -24,7 +24,7 @@ bool isGeneric(Element element) =>
 
 String dataFieldType(obj) {
   return _genericOf(ConstantReader(obj).objectValue.type)
-      .displayName
+      .getDisplayString()
       .replaceAll('Generic', 'T');
 }
 
@@ -52,6 +52,6 @@ String usedWrapperNameFromAnnotation(FieldElement field) {
 
 String _defaultWrapper(FieldElement field) {
   final usedClass = usedClassFromAnnotation(field);
-  final usedClassType = usedClass.toTypeValue().name;
+  final usedClassType = usedClass.toTypeValue().getDisplayString();
   return '${usedClassType}Wrapper';
 }

--- a/super_enum_generator/pubspec.yaml
+++ b/super_enum_generator/pubspec.yaml
@@ -4,15 +4,17 @@ version: 0.4.1
 homepage: https://github.com/xsahil03x/super_enum
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
 
   # Specify a specific version or a version constraint
   # for "super_enum" before publishing the package.
-  super_enum: ^0.4.1
+#  super_enum: ^0.4.1
+  super_enum:
+    path: ../super_enum
   source_gen: ^0.9.4+7
-  analyzer: '>=0.36.0 <0.40.0'
+  analyzer: '>=0.39.2 <0.40.0'
   build: '>=0.12.6 <2.0.0'
   code_builder: ^3.2.0
   dart_style: ^1.3.3

--- a/super_enum_generator/test/src/use_class_test_src.dart
+++ b/super_enum_generator/test/src/use_class_test_src.dart
@@ -10,14 +10,23 @@ abstract class ResultUnion extends Equatable {
 
   factory ResultUnion.error(MyError myError) = MyErrorWrapper;
 
+  factory ResultUnion.specialError(MyError myError) = MyErrorWrapper;
+
+  factory ResultUnion.yetAnotherError(MyError myError) = YaeWrapper;
+
   final _ResultUnion _type;
 
 //ignore: missing_return
   FutureOr<R> when<R>(
       {@required FutureOr<R> Function(MySuccess) success,
-      @required FutureOr<R> Function(MyError) error}) {
+      @required FutureOr<R> Function(MyError) error,
+      @required FutureOr<R> Function(MyError) specialError,
+      @required FutureOr<R> Function(MyError) yetAnotherError}) {
     assert(() {
-      if (success == null || error == null) {
+      if (success == null ||
+          error == null ||
+          specialError == null ||
+          yetAnotherError == null) {
         throw 'check for all possible cases';
       }
       return true;
@@ -27,12 +36,18 @@ abstract class ResultUnion extends Equatable {
         return success((this as MySuccessWrapper).mySuccess);
       case _ResultUnion.Error:
         return error((this as MyErrorWrapper).myError);
+      case _ResultUnion.SpecialError:
+        return specialError((this as MyErrorWrapper).myError);
+      case _ResultUnion.YetAnotherError:
+        return yetAnotherError((this as YaeWrapper).myError);
     }
   }
 
   FutureOr<R> whenOrElse<R>(
       {FutureOr<R> Function(MySuccess) success,
       FutureOr<R> Function(MyError) error,
+      FutureOr<R> Function(MyError) specialError,
+      FutureOr<R> Function(MyError) yetAnotherError,
       @required FutureOr<R> Function(ResultUnion) orElse}) {
     assert(() {
       if (orElse == null) {
@@ -47,15 +62,26 @@ abstract class ResultUnion extends Equatable {
       case _ResultUnion.Error:
         if (error == null) break;
         return error((this as MyErrorWrapper).myError);
+      case _ResultUnion.SpecialError:
+        if (specialError == null) break;
+        return specialError((this as MyErrorWrapper).myError);
+      case _ResultUnion.YetAnotherError:
+        if (yetAnotherError == null) break;
+        return yetAnotherError((this as YaeWrapper).myError);
     }
     return orElse(this);
   }
 
   FutureOr<void> whenPartial(
       {FutureOr<void> Function(MySuccess) success,
-      FutureOr<void> Function(MyError) error}) {
+      FutureOr<void> Function(MyError) error,
+      FutureOr<void> Function(MyError) specialError,
+      FutureOr<void> Function(MyError) yetAnotherError}) {
     assert(() {
-      if (success == null && error == null) {
+      if (success == null &&
+          error == null &&
+          specialError == null &&
+          yetAnotherError == null) {
         throw 'provide at least one branch';
       }
       return true;
@@ -67,6 +93,12 @@ abstract class ResultUnion extends Equatable {
       case _ResultUnion.Error:
         if (error == null) break;
         return error((this as MyErrorWrapper).myError);
+      case _ResultUnion.SpecialError:
+        if (specialError == null) break;
+        return specialError((this as MyErrorWrapper).myError);
+      case _ResultUnion.YetAnotherError:
+        if (yetAnotherError == null) break;
+        return yetAnotherError((this as YaeWrapper).myError);
     }
   }
 
@@ -97,6 +129,18 @@ class MyErrorWrapper extends ResultUnion {
   @override
   List get props => [myError];
 }
+
+@immutable
+class YaeWrapper extends ResultUnion {
+  const YaeWrapper(this.myError) : super(_ResultUnion.YetAnotherError);
+
+  final MyError myError;
+
+  @override
+  String toString() => 'YaeWrapper($myError)';
+  @override
+  List get props => [myError];
+}
 ''')
 @superEnum
 // ignore: unused_element
@@ -104,8 +148,17 @@ enum _ResultUnion {
   @UseClass(MySuccess)
   Success,
 
+  // duplicate class without custom name, doesn't result in double wrapper
   @UseClass(MyError)
   Error,
+
+  // duplicate class without custom name, doesn't result in double wrapper
+  @UseClass(MyError)
+  SpecialError,
+
+  // Custom name for the wrapper
+  @UseClass(MyError, name: "YaeWrapper")
+  YetAnotherError,
 }
 
 class MySuccess {


### PR DESCRIPTION
Do not generate the same `@UseClass` wrappers multiple times

Also adds support for a 'name' parameter, for even more control when the default doesn't satisfy naming. This may happen when reusing a the class across multiple enums. 

fixes #42

Also: Seems like `analyzer` pushed a slightly breaking changes in a patch release. Worked on my machine but not on CI.